### PR TITLE
Expose PDF/HTML config and decouple DraftForge packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -2,87 +2,15 @@
 
 A lightweight, stack-agnostic library for **web-native rich text authoring, live preview, and background PDF export**.
 
+This repository hosts two independent packages:
+
 - `packages/react` — React components built on **Editor.js**: `Editor`, `Preview`, `ExportButton`, plus `renderToHtml` helper.
 - `packages/rails` — Rails engine (`draft_forge`) exposing `/draftforge/exports` for async HTML→PDF via **Grover** (Puppeteer). Includes server-side HTML sanitization and Active Storage delivery.
 
-## Quickstart
+Each package can be used on its own or combined. Refer to their READMEs for setup and configuration:
 
-### 1) Rails API (engine)
-
-#### **Gemfile**
-
-```ruby
-gem 'draft_forge', path: './packages/rails'
-gem 'grover'
-gem 'sanitize'
-```
-
-```bash
-bundle install
-bin/rails active_storage:install # if not present
-bin/rails db:migrate
-```
-
-#### **config/routes.rb**
-
-```ruby
-mount DraftForge::Engine => '/draftforge'
-```
-
-You now have:
-
-- `POST /draftforge/exports` → `{ id, status }`
-- `GET  /draftforge/exports/:id` → `{ id, status }` or `{ id, status: "complete", download_url }`
-
-Ensure headless Chrome/Chromium is available for Grover.
-
-### 2) UI (React + Editor.js)
-
-From `packages/react`:
-
-```bash
-pnpm i   # or npm i / yarn
-pnpm build
-```
-
-In your app:
-
-```tsx
-import { Editor, Preview, ExportButton, renderToHtml } from 'draftforge';
-import { useState } from 'react';
-
-export default function Composer() {
-  const [data, setData] = useState<any>({ blocks: [{ type: 'header', data: { text: 'Draft', level: 2 } }] });
-
-  return (
-    <div className="grid grid-cols-2 gap-6">
-      <Editor
-        initialData={data}
-        onChangeData={setData}
-        uploadImage={async (file) => {
-          const form = new FormData();
-          form.append('file', file);
-          const res = await fetch('/uploads', { method: 'POST', body: form });
-          const { url } = await res.json();
-          return url;
-        }}
-      />
-      <div>
-        <Preview data={data} className="prose max-w-none" />
-        <ExportButton
-          data={data}
-          filename="document.pdf"
-          exportUrl="/draftforge/exports"
-          pollBaseUrl="/draftforge/exports"
-          onReady={(url) => window.open(url, '_blank')}
-        />
-      </div>
-    </div>
-  );
-}
-```
-
-> Client converts Editor.js JSON → HTML for preview/export; server sanitizes and renders PDF in the background.
+- [React components](packages/react/README.md)
+- [Rails engine](packages/rails/README.md)
 
 ## Notes
 

--- a/packages/rails/README.md
+++ b/packages/rails/README.md
@@ -1,3 +1,20 @@
 # draft_forge
 
-Rails engine for exporting HTML to PDF.
+Rails engine for exporting HTML to PDF. Can be paired with any front-end or used standalone.
+
+## Configuration
+
+`DraftForge` exposes simple configuration hooks for PDF rendering and HTML
+sanitization. The sanitizer controls which HTML elements (blocks) are allowed,
+letting you distinguish between editable and non-editable content.
+
+```ruby
+# config/initializers/draft_forge.rb
+DraftForge.configure do |config|
+  # Change page size/margins for Grover
+  config.pdf_options = { format: 'Letter' }
+
+  # Permit additional HTML elements
+  config.sanitizer_config[:elements] += %w[hr]
+end
+```

--- a/packages/rails/app/jobs/draft_forge/export_pdf_job.rb
+++ b/packages/rails/app/jobs/draft_forge/export_pdf_job.rb
@@ -12,7 +12,7 @@ module DraftForge
       safe_html = HtmlSanitizer.call(raw_html)
       html = wrap_html(safe_html)
 
-      pdf = Grover.new(html, format: 'A4', margin: { top: '20mm', right: '15mm', bottom: '20mm', left: '15mm' }).to_pdf
+      pdf = Grover.new(html, DraftForge.pdf_options).to_pdf
 
       filename = export.requested_filename.presence || "document.pdf"
       export.pdf.attach(io: StringIO.new(pdf), filename: filename, content_type: 'application/pdf')
@@ -25,6 +25,14 @@ module DraftForge
     private
 
     def wrap_html(body)
+      options = DraftForge.pdf_options
+      size = options[:format] || 'A4'
+      margin = options[:margin] || {}
+      top = margin[:top] || '20mm'
+      right = margin[:right] || '15mm'
+      bottom = margin[:bottom] || '20mm'
+      left = margin[:left] || '15mm'
+
       <<~HTML
         <!doctype html>
         <html>
@@ -32,7 +40,7 @@ module DraftForge
             <meta charset="utf-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1" />
             <style>
-              @page { size: A4; margin: 20mm 15mm; }
+              @page { size: #{size}; margin: #{top} #{right} #{bottom} #{left}; }
               body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', Arial, 'Noto Sans', 'Liberation Sans', sans-serif; font-size: 12px; line-height: 1.45; color: #111; }
               h1, h2, h3 { margin: 0 0 8px; }
               h1 { font-size: 22px; }

--- a/packages/rails/app/services/draft_forge/html_sanitizer.rb
+++ b/packages/rails/app/services/draft_forge/html_sanitizer.rb
@@ -1,24 +1,9 @@
 # frozen_string_literal: true
 module DraftForge
   class HtmlSanitizer
-    CONFIG = {
-      elements: Sanitize::Config::RELAXED[:elements] + %w[table thead tbody tfoot tr td th figure figcaption],
-      attributes: {
-        'a' => ['href', 'title', 'target', 'rel'],
-        'img' => ['src', 'alt', 'title', 'width', 'height'],
-        'td' => ['colspan', 'rowspan', 'style'],
-        'th' => ['colspan', 'rowspan', 'style'],
-        :all => ['class', 'style']
-      },
-      protocols: {
-        'a' => { 'href' => ['http', 'https', 'mailto', 'tel', :relative] },
-        'img' => { 'src'  => ['http', 'https', :relative] }
-      },
-      transformers: []
-    }
-
     def self.call(html)
-      Sanitize.fragment(html.to_s, CONFIG.merge(remove_contents: ['script', 'style']))
+      config = DraftForge.sanitizer_config
+      Sanitize.fragment(html.to_s, config.merge(remove_contents: ['script', 'style']))
     end
   end
 end

--- a/packages/rails/lib/draft_forge.rb
+++ b/packages/rails/lib/draft_forge.rb
@@ -2,6 +2,29 @@
 
 require "draft_forge/version"
 require "draft_forge/engine"
+require "sanitize"
 
 module DraftForge
+  DEFAULT_SANITIZER_CONFIG = {
+    elements: Sanitize::Config::RELAXED[:elements] + %w[table thead tbody tfoot tr td th figure figcaption],
+    attributes: {
+      'a' => ['href', 'title', 'target', 'rel'],
+      'img' => ['src', 'alt', 'title', 'width', 'height'],
+      'td' => ['colspan', 'rowspan', 'style'],
+      'th' => ['colspan', 'rowspan', 'style'],
+      :all => ['class', 'style']
+    },
+    protocols: {
+      'a' => { 'href' => ['http', 'https', 'mailto', 'tel', :relative] },
+      'img' => { 'src'  => ['http', 'https', :relative] }
+    },
+    transformers: []
+  }.freeze
+
+  mattr_accessor :sanitizer_config, default: DEFAULT_SANITIZER_CONFIG
+  mattr_accessor :pdf_options, default: { format: 'A4', margin: { top: '20mm', right: '15mm', bottom: '20mm', left: '15mm' } }
+
+  def self.configure
+    yield self
+  end
 end

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,52 @@
+# DraftForge React
+
+Standalone React components for rich-text authoring and PDF export. Includes:
+
+- **Editor** – block-based editor powered by Editor.js
+- **Preview** – client-side HTML preview of Editor.js data
+- **ExportButton** – kicks off an export and polls for completion
+- **renderToHtml** – helper for server-side rendering
+
+## Installation
+
+```bash
+npm install draftforge
+```
+
+## Build
+
+From this directory:
+
+```bash
+pnpm i
+pnpm build
+```
+
+## Usage
+
+The components are backend-agnostic. Provide URLs for your own export service:
+
+```tsx
+import { Editor, Preview, ExportButton } from 'draftforge';
+import { useState } from 'react';
+
+export default function Composer() {
+  const [data, setData] = useState({ blocks: [] });
+
+  return (
+    <>
+      <Editor initialData={data} onChangeData={setData} />
+      <Preview data={data} />
+      <ExportButton
+        data={data}
+        filename="document.pdf"
+        exportUrl="/exports"
+        pollBaseUrl="/exports"
+      />
+    </>
+  );
+}
+```
+
+Use with any backend capable of accepting Editor.js JSON and returning a PDF URL when ready.
+


### PR DESCRIPTION
## Summary
- expose DraftForge.configure with pdf_options and sanitizer_config
- document independent React UI and Rails engine, with separate READMEs
- ignore build artifacts for cleaner repos

## Testing
- `ruby -c packages/rails/lib/draft_forge.rb`
- `ruby -c packages/rails/app/services/draft_forge/html_sanitizer.rb`
- `ruby -c packages/rails/app/jobs/draft_forge/export_pdf_job.rb`


------
https://chatgpt.com/codex/tasks/task_e_68ada599cc8c8325bfb87554dcfcd3be