### PR TITLE
Allow contenteditable for live editing

### DIFF
--- a/packages/rails/README.md
+++ b/packages/rails/README.md
@@ -6,7 +6,9 @@ Rails engine for exporting HTML to PDF. Can be paired with any front-end or used
 
 `DraftForge` exposes simple configuration hooks for PDF rendering and HTML
 sanitization. The sanitizer controls which HTML elements (blocks) are allowed,
-letting you distinguish between editable and non-editable content.
+letting you distinguish between editable and non-editable content. By default
+the sanitizer permits the `contenteditable` attribute so sanitized markup can
+be used in live editors.
 
 ```ruby
 # config/initializers/draft_forge.rb

--- a/packages/rails/lib/draft_forge.rb
+++ b/packages/rails/lib/draft_forge.rb
@@ -12,7 +12,7 @@ module DraftForge
       'img' => ['src', 'alt', 'title', 'width', 'height'],
       'td' => ['colspan', 'rowspan', 'style'],
       'th' => ['colspan', 'rowspan', 'style'],
-      :all => ['class', 'style']
+      :all => ['class', 'style', 'contenteditable']
     },
     protocols: {
       'a' => { 'href' => ['http', 'https', 'mailto', 'tel', :relative] },


### PR DESCRIPTION
## Summary
- Preserve `contenteditable` attribute in sanitizer configuration to support live editing
- Document default `contenteditable` allowance for sanitized markup

## Testing
- `ruby -c packages/rails/lib/draft_forge.rb`
- `cd packages/rails && bundle exec rake` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68adaf594f008325b82df6d384d27c19