### PR TITLE
feat: allow mounting in rails routes

### DIFF
--- a/packages/rails/README.md
+++ b/packages/rails/README.md
@@ -2,6 +2,29 @@
 
 Rails engine for exporting HTML to PDF. Can be paired with any front-end or used standalone.
 
+## Installation
+
+Copy an initializer and migration into your application:
+
+```bash
+bin/rails generate draft_forge:install
+```
+
+## Mounting
+
+Expose DraftForge's endpoints by mounting the engine in your application's
+routes:
+
+```ruby
+# config/routes.rb
+Rails.application.routes.draw do
+  mount DraftForge::Engine => "/draft_forge"
+end
+```
+
+This provides `POST /draft_forge` to queue a PDF export and
+`GET /draft_forge/:id` to check status or download the finished file.
+
 ## Configuration
 
 `DraftForge` exposes simple configuration hooks for PDF rendering and HTML

--- a/packages/rails/config/routes.rb
+++ b/packages/rails/config/routes.rb
@@ -1,3 +1,3 @@
 DraftForge::Engine.routes.draw do
-  resources :exports, only: [:create, :show]
+  resources :exports, only: %i[create show], path: ''
 end

--- a/packages/rails/lib/generators/draft_forge/install/install_generator.rb
+++ b/packages/rails/lib/generators/draft_forge/install/install_generator.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/migration"
+
+module DraftForge
+  module Generators
+    class InstallGenerator < Rails::Generators::Base
+      include Rails::Generators::Migration
+
+      source_root File.expand_path("templates", __dir__)
+
+      def copy_initializer
+        template "draft_forge.rb", "config/initializers/draft_forge.rb"
+      end
+
+      def copy_migration
+        unless migration_exists?("db/migrate", "create_draft_forge_exports")
+          migration_template "create_draft_forge_exports.rb", "db/migrate/create_draft_forge_exports.rb"
+        end
+      end
+
+      def self.next_migration_number(dirname)
+        Time.now.utc.strftime("%Y%m%d%H%M%S")
+      end
+
+      private
+
+      def migration_exists?(dir, name)
+        Dir.glob(File.join(destination_root, dir, "*_#{name}.rb")).any?
+      end
+    end
+  end
+end

--- a/packages/rails/lib/generators/draft_forge/install/templates/create_draft_forge_exports.rb
+++ b/packages/rails/lib/generators/draft_forge/install/templates/create_draft_forge_exports.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateDraftForgeExports < ActiveRecord::Migration[7.1]
+  def change
+    create_table :draft_forge_exports, id: :uuid do |t|
+      t.integer :status, null: false, default: 0
+      t.string  :requested_filename
+      t.timestamps
+    end
+  end
+end

--- a/packages/rails/lib/generators/draft_forge/install/templates/draft_forge.rb
+++ b/packages/rails/lib/generators/draft_forge/install/templates/draft_forge.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+DraftForge.configure do |config|
+  # Change page size/margins for Grover
+  # config.pdf_options = { format: 'Letter' }
+
+  # Permit additional HTML elements
+  # config.sanitizer_config[:elements] += %w[hr]
+end


### PR DESCRIPTION
## Summary
- allow DraftForge engine to be mounted at custom path
- document mounting usage in README
- provide install generator for copying migration and initializer

## Testing
- `bundle exec rake -T`


------
https://chatgpt.com/codex/tasks/task_e_68adb3b2236c83258b909dfd4e0feb7e