### PR TITLE
Add RSpec test suite for Rails package

### DIFF
--- a/packages/rails/Gemfile.lock
+++ b/packages/rails/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     connection_pool (2.5.3)
     crass (1.0.6)
     date (3.4.1)
+    diff-lcs (1.6.2)
     drb (2.2.3)
     erb (5.0.2)
     erubi (1.13.1)
@@ -190,6 +191,19 @@ GEM
       psych (>= 4.0.0)
     reline (0.6.2)
       io-console (~> 0.5)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.5)
     sanitize (7.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.16.8)
@@ -219,6 +233,7 @@ PLATFORMS
 
 DEPENDENCIES
   draft_forge!
+  rspec (~> 3.12)
 
 BUNDLED WITH
    2.6.7

--- a/packages/rails/Rakefile
+++ b/packages/rails/Rakefile
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec
 

--- a/packages/rails/draft_forge.gemspec
+++ b/packages/rails/draft_forge.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", ">= 7.1", "< 9.0"
   spec.add_dependency "grover", ">= 1.1"
   spec.add_dependency "sanitize", ">= 6.1"
+  spec.add_development_dependency "rspec", "~> 3.12"
 end

--- a/packages/rails/spec/configuration_spec.rb
+++ b/packages/rails/spec/configuration_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Configuration" do
+  before do
+    DraftForge.sanitizer_config = Marshal.load(Marshal.dump(DraftForge::DEFAULT_SANITIZER_CONFIG))
+    DraftForge.pdf_options = { format: 'A4', margin: { top: '20mm', right: '15mm', bottom: '20mm', left: '15mm' } }
+  end
+
+  it "uses default sanitizer config" do
+    expect(DraftForge.sanitizer_config[:elements]).to include('table')
+    expect(DraftForge.sanitizer_config[:attributes][:all]).to include('contenteditable')
+  end
+
+  it "allows configuration overrides" do
+    DraftForge.configure do |config|
+      config.pdf_options = { format: 'Letter' }
+      config.sanitizer_config[:elements] += ['hr']
+    end
+
+    expect(DraftForge.pdf_options).to eq({ format: 'Letter' })
+    expect(DraftForge.sanitizer_config[:elements]).to include('hr')
+  end
+
+  it "sanitizes custom elements and attributes" do
+    html = '<table class="t"><tr><td contenteditable="true">X</td></tr></table>'
+    sanitized = Sanitize.fragment(html, DraftForge.sanitizer_config)
+
+    expect(sanitized).to include('<table')
+    expect(sanitized).to include('class="t"')
+    expect(sanitized).to include('contenteditable="true"')
+  end
+end
+

--- a/packages/rails/spec/engine_spec.rb
+++ b/packages/rails/spec/engine_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe DraftForge::Engine do
+  it "inherits from Rails::Engine" do
+    expect(DraftForge::Engine.instance).to be_a(Rails::Engine)
+  end
+
+  it "is isolated" do
+    expect(DraftForge::Engine.isolated?).to be(true)
+  end
+end
+

--- a/packages/rails/spec/install_generator_spec.rb
+++ b/packages/rails/spec/install_generator_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fileutils"
+require "generators/draft_forge/install/install_generator"
+
+RSpec.describe DraftForge::Generators::InstallGenerator do
+  it "creates initializer and migration" do
+    destination = File.expand_path("tmp/destination", __dir__)
+    FileUtils.rm_rf(destination)
+
+    DraftForge::Generators::InstallGenerator.start([], destination_root: destination)
+
+    initializer = File.join(destination, "config/initializers/draft_forge.rb")
+    migration = Dir.glob(File.join(destination, "db/migrate/*_create_draft_forge_exports.rb")).first
+
+    expect(File.exist?(initializer)).to be(true)
+    expect(migration).not_to be_nil
+    expect(File.read(migration)).to match(/create_table :draft_forge_exports/)
+  end
+end
+

--- a/packages/rails/spec/routes_spec.rb
+++ b/packages/rails/spec/routes_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Routes" do
+  before do
+    load DraftForge::Engine.root.join("config/routes.rb")
+  end
+
+  it "exposes export endpoints" do
+    routes = DraftForge::Engine.routes.routes.map do |r|
+      [r.verb, r.path.spec.to_s, r.defaults[:controller], r.defaults[:action]]
+    end
+
+    expect(routes).to include(["POST", "/", "draft_forge/exports", "create"])
+    expect(routes).to include(["GET", "/:id(.:format)", "draft_forge/exports", "show"])
+  end
+end
+

--- a/packages/rails/spec/spec_helper.rb
+++ b/packages/rails/spec/spec_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "draft_forge"
+require "rspec"
+require "sanitize"
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end
+


### PR DESCRIPTION
## Summary
- replace Minitest tests with RSpec specs covering configuration, engine isolation, generator, and routes
- run specs via Rake and include RSpec as a development dependency

## Testing
- `cd packages/rails && bundle exec rake spec`


------
https://chatgpt.com/codex/tasks/task_e_68adc65666ac8325b10a2fb13cef117b