### PR TITLE
Support Editor.js JSON in PDF exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A lightweight, stack-agnostic library for **web-native rich text authoring, live
 This repository hosts two independent packages:
 
 - `packages/react` — React components built on **Editor.js**: `Editor`, `Preview`, plus helpers for HTML rendering and export delegation.
-- `packages/rails` — Rails engine (`draft_forge`) exposing `/draftforge/exports` for async HTML→PDF via **Grover** (Puppeteer). Includes server-side HTML sanitization and Active Storage delivery.
+- `packages/rails` — Rails engine (`draft_forge`) exposing `/draftforge/exports` for async HTML or Editor.js JSON → PDF via **Grover** (Puppeteer). Includes server-side HTML sanitization and Active Storage delivery.
 
 Each package can be used on its own or combined. Refer to their READMEs for setup and configuration:
 

--- a/packages/rails/README.md
+++ b/packages/rails/README.md
@@ -1,6 +1,6 @@
 # draft_forge
 
-Rails engine for exporting HTML to PDF. Can be paired with any front-end or used standalone.
+Rails engine for exporting HTML or Editor.js JSON to PDF. Can be paired with any front-end or used standalone.
 
 ## Installation
 
@@ -35,7 +35,7 @@ directly with service objects:
 
 ```ruby
 export = DraftForge::CreateExport.call(
-  content_html: "<p>Hello world</p>",
+  content_json: { blocks: [{ type: 'paragraph', data: { text: 'Hello world' } }] },
   filename: "hello.pdf"
 )
 

--- a/packages/rails/app/controllers/draft_forge/exports_controller.rb
+++ b/packages/rails/app/controllers/draft_forge/exports_controller.rb
@@ -5,7 +5,11 @@ module DraftForge
     before_action :ensure_json
 
     def create
-      html = params[:content_html].to_s
+      html = if params[:content_json].present?
+               EditorJsRenderer.call(params[:content_json])
+             else
+               params[:content_html].to_s
+             end
       filename = params[:filename].presence || "document.pdf"
 
       export = Export.create!(status: :queued, requested_filename: filename)

--- a/packages/rails/app/services/draft_forge/create_export.rb
+++ b/packages/rails/app/services/draft_forge/create_export.rb
@@ -2,12 +2,16 @@
 
 module DraftForge
   class CreateExport
-    def self.call(content_html:, filename: nil)
+    def self.call(content_html: nil, content_json: nil, filename: nil)
       unless Export.table_exists?
         Rails.logger.error("[DraftForge] Missing `draft_forge_exports` table. Run `rails generate draft_forge:install` and `rails db:migrate`.")
         return
       end
-      html = content_html.to_s
+      html = if content_json
+               EditorJsRenderer.call(content_json)
+             else
+               content_html.to_s
+             end
       name = filename.presence || 'document.pdf'
 
       export = Export.create!(status: :queued, requested_filename: name)

--- a/packages/rails/app/services/draft_forge/editor_js_renderer.rb
+++ b/packages/rails/app/services/draft_forge/editor_js_renderer.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module DraftForge
+  # Convert Editor.js data to basic HTML
+  class EditorJsRenderer
+    def self.call(data)
+      data = parse(data)
+      blocks = data.fetch('blocks', [])
+      blocks.map { |block| render_block(block) }.join
+    end
+
+    def self.parse(data)
+      if data.is_a?(String)
+        JSON.parse(data)
+      elsif data.respond_to?(:to_unsafe_h)
+        data.to_unsafe_h
+      else
+        data || {}
+      end
+    end
+
+    def self.render_block(block)
+      type = block['type']
+      bdata = block['data'] || {}
+      case type
+      when 'paragraph'
+        "<p>#{bdata['text']}</p>"
+      when 'header'
+        level = bdata['level'].to_i
+        level = 1 if level < 1
+        level = 6 if level > 6
+        "<h#{level}>#{bdata['text']}</h#{level}>"
+      when 'list'
+        tag = bdata['style'] == 'ordered' ? 'ol' : 'ul'
+        items = Array(bdata['items']).map { |item| "<li>#{item}</li>" }.join
+        "<#{tag}>#{items}</#{tag}>"
+      else
+        ''
+      end
+    end
+  end
+end

--- a/packages/rails/spec/editor_js_renderer_spec.rb
+++ b/packages/rails/spec/editor_js_renderer_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require_relative '../app/services/draft_forge/editor_js_renderer'
+
+RSpec.describe DraftForge::EditorJsRenderer do
+  it 'renders basic blocks to html' do
+    data = {
+      'blocks' => [
+        { 'type' => 'header', 'data' => { 'text' => 'Title', 'level' => 2 } },
+        { 'type' => 'paragraph', 'data' => { 'text' => 'Hello' } },
+        { 'type' => 'list', 'data' => { 'style' => 'unordered', 'items' => ['a', 'b'] } }
+      ]
+    }
+    html = described_class.call(data)
+    expect(html).to include('<h2>Title</h2>')
+    expect(html).to include('<p>Hello</p>')
+    expect(html).to include('<ul><li>a</li><li>b</li></ul>')
+  end
+end

--- a/packages/react/__tests__/exportDocument.test.ts
+++ b/packages/react/__tests__/exportDocument.test.ts
@@ -19,6 +19,8 @@ describe('exportDocument', () => {
     });
     expect(url).toBe('/file.pdf');
     expect(calls[0].url).toBe('/export');
+    const body = JSON.parse(calls[0].opts.body);
+    expect(body.content_json).toEqual({ blocks: [] });
   });
 
   it('throws on export failure', async () => {

--- a/packages/react/src/exportDocument.ts
+++ b/packages/react/src/exportDocument.ts
@@ -1,4 +1,3 @@
-import { renderToHtml } from './renderToHtml';
 import type { ExportOptions } from './types';
 
 /**
@@ -15,11 +14,10 @@ export async function exportDocument({
   pollIntervalMs = 1000,
   maxPolls = 60
 }: ExportOptions): Promise<string> {
-  const html = renderToHtml(data);
   const res = await fetchImpl(exportUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ content_html: html, filename })
+    body: JSON.stringify({ content_json: data, filename })
   });
   if (!res.ok) throw new Error(`Export request failed: ${res.status}`);
   const { id } = await res.json();


### PR DESCRIPTION
## Summary
- allow exporting Editor.js JSON directly to PDF via new server-side renderer
- update React helper to send Editor.js data as JSON instead of pre-rendered HTML
- document JSON export capabilities in root and Rails READMEs

## Testing
- `cd packages/react && npm test`
- `cd packages/rails && bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_68add252e3c883258d179fc95c36e1fc