### PR TITLE
feat(react): add accessible label to editor

### DIFF
--- a/packages/react/__tests__/Editor.test.tsx
+++ b/packages/react/__tests__/Editor.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { Editor } from '../src/Editor';
+
+jest.mock('@editorjs/editorjs', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({ destroy: jest.fn() })),
+}));
+
+jest.mock('@editorjs/header', () => ({ __esModule: true, default: function () {} }));
+jest.mock('@editorjs/list', () => ({ __esModule: true, default: function () {} }));
+jest.mock('@editorjs/checklist', () => ({ __esModule: true, default: function () {} }));
+jest.mock('@editorjs/table', () => ({ __esModule: true, default: function () {} }));
+jest.mock('@editorjs/quote', () => ({ __esModule: true, default: function () {} }));
+jest.mock('@editorjs/code', () => ({ __esModule: true, default: function () {} }));
+jest.mock('@editorjs/image', () => ({ __esModule: true, default: function () {} }));
+
+describe('Editor', () => {
+  it('uses provided aria-label', () => {
+    render(<Editor ariaLabel="Custom label" />);
+    expect(screen.getByLabelText('Custom label')).toBeTruthy();
+  });
+
+  it('defaults aria-label when not provided', () => {
+    render(<Editor />);
+    expect(screen.getByLabelText('Rich text editor')).toBeTruthy();
+  });
+});
+

--- a/packages/react/src/Editor.tsx
+++ b/packages/react/src/Editor.tsx
@@ -9,7 +9,13 @@ import CodeTool from '@editorjs/code';
 import ImageTool from '@editorjs/image';
 import type { EditorProps } from './types';
 
-export function Editor({ initialData, onChangeData, uploadImage, className }: EditorProps) {
+export function Editor({
+  initialData,
+  onChangeData,
+  uploadImage,
+  className,
+  ariaLabel = 'Rich text editor',
+}: EditorProps) {
   const holderRef = useRef<HTMLDivElement | null>(null);
   const editorRef = useRef<EditorJS | null>(null);
 
@@ -56,7 +62,11 @@ export function Editor({ initialData, onChangeData, uploadImage, className }: Ed
 
   return (
     <div className={className}>
-      <div ref={holderRef} style={{ border: '1px solid #ddd', borderRadius: 8, padding: 12, minHeight: 280 }} />
+      <div
+        ref={holderRef}
+        aria-label={ariaLabel}
+        style={{ border: '1px solid #ddd', borderRadius: 8, padding: 12, minHeight: 280 }}
+      />
     </div>
   );
 }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -11,6 +11,8 @@ export interface EditorProps {
   onChangeData?: (data: EditorJsData) => void;
   uploadImage?: UploadImageFn;
   className?: string;
+  /** Accessible label for the editor region */
+  ariaLabel?: string;
 }
 
 export interface PreviewProps {


### PR DESCRIPTION
## Summary
- allow customizing aria-label for Editor region
- test Editor accessibility defaults and overrides

## Testing
- `cd packages/react && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ade50784a48325a33e7c70a58840e8