### PR TITLE
Add gem metadata and changelog

### DIFF
--- a/packages/rails/CHANGELOG.md
+++ b/packages/rails/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.3.0
+
+- Initial release.

--- a/packages/rails/README.md
+++ b/packages/rails/README.md
@@ -2,6 +2,8 @@
 
 Rails engine for exporting HTML or Editor.js JSON to PDF. Can be paired with any front-end or used standalone.
 
+Requires Ruby 3.1 or higher. See [CHANGELOG](CHANGELOG.md) for release notes.
+
 ## Installation
 
 Copy an initializer and migration into your application:

--- a/packages/rails/draft_forge.gemspec
+++ b/packages/rails/draft_forge.gemspec
@@ -10,8 +10,15 @@ Gem::Specification.new do |spec|
   spec.summary       = "DraftForge — Rails engine for HTML->PDF exports"
   spec.description   = "A minimal Rails engine exposing endpoints to export sanitized HTML to PDF via Grover."
   spec.license       = "MIT"
+  spec.homepage      = "https://github.com/draftforge/draftforge"
   spec.require_paths = ["lib"]
-  spec.files         = Dir.chdir(__dir__) { Dir["{app,config,lib}/**/*", "MIT-LICENSE", "README.md"] }
+  spec.files         = Dir.chdir(__dir__) { Dir["{app,config,lib}/**/*", "MIT-LICENSE", "README.md", "CHANGELOG.md"] }
+
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.1")
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/packages/rails/CHANGELOG.md"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.add_dependency "rails", ">= 7.1", "< 9.0"
   spec.add_dependency "grover", ">= 1.1"


### PR DESCRIPTION
## Summary
- add homepage, metadata, and Ruby version requirement to gemspec
- document Ruby version and changelog in README
- create initial changelog file

## Testing
- `bundle install`
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_68ade75bbea483258c3289795164e848