### PR TITLE
feat: enhance EditorJS integration

### DIFF
--- a/packages/react/__tests__/Editor.test.tsx
+++ b/packages/react/__tests__/Editor.test.tsx
@@ -4,6 +4,7 @@ import { Editor } from '../src/Editor';
 jest.mock('@editorjs/editorjs', () => ({
   __esModule: true,
   default: jest.fn().mockImplementation(() => ({ destroy: jest.fn() })),
+  LogLevels: { ERROR: 'ERROR' }
 }));
 
 jest.mock('@editorjs/header', () => ({ __esModule: true, default: function () {} }));
@@ -23,6 +24,14 @@ describe('Editor', () => {
   it('defaults aria-label when not provided', () => {
     render(<Editor />);
     expect(screen.getByLabelText('Rich text editor')).toBeTruthy();
+  });
+
+  it('passes placeholder to Editor.js', () => {
+    const EditorJS = require('@editorjs/editorjs').default as jest.Mock;
+    render(<Editor placeholder="Type here" />);
+    expect(EditorJS).toHaveBeenCalledWith(
+      expect.objectContaining({ placeholder: 'Type here' })
+    );
   });
 });
 

--- a/packages/react/src/Editor.tsx
+++ b/packages/react/src/Editor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import EditorJS from '@editorjs/editorjs';
+import EditorJS, { LogLevels } from '@editorjs/editorjs';
 import Header from '@editorjs/header';
 import List from '@editorjs/list';
 import Checklist from '@editorjs/checklist';
@@ -15,6 +15,9 @@ export function Editor({
   uploadImage,
   className,
   ariaLabel = 'Rich text editor',
+  placeholder,
+  readOnly,
+  onReady,
 }: EditorProps) {
   const holderRef = useRef<HTMLDivElement | null>(null);
   const editorRef = useRef<EditorJS | null>(null);
@@ -25,6 +28,9 @@ export function Editor({
     const editor = new EditorJS({
       holder: holderRef.current,
       data: initialData || { blocks: [{ type: 'paragraph', data: { text: '' } }] },
+      placeholder,
+      readOnly,
+      logLevel: LogLevels.ERROR,
       tools: {
         paragraph: { inlineToolbar: true },
         header: { class: Header as any, inlineToolbar: true },
@@ -50,6 +56,9 @@ export function Editor({
       async onChange(api) {
         const data = await api.saver.save();
         onChangeData?.(data as any);
+      },
+      onReady() {
+        onReady?.(editor);
       }
     });
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,3 +1,5 @@
+import type EditorJS from '@editorjs/editorjs';
+
 export type UploadImageFn = (file: File) => Promise<string>;
 
 export interface EditorJsData {
@@ -13,6 +15,12 @@ export interface EditorProps {
   className?: string;
   /** Accessible label for the editor region */
   ariaLabel?: string;
+  /** Placeholder text shown in the first empty block */
+  placeholder?: string;
+  /** Toggle read-only mode */
+  readOnly?: boolean;
+  /** Callback once the Editor.js instance is ready */
+  onReady?: (editor: EditorJS) => void;
 }
 
 export interface PreviewProps {


### PR DESCRIPTION
## Summary
- add placeholder, read-only, and onReady support to Editor component
- tighten Editor.js log level to ERROR
- test placeholder prop handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ade8db169c8325a724fd26433630e0