### PR TITLE
refactor: externalize editor styles

### DIFF
--- a/packages/react/__mocks__/styleMock.js
+++ b/packages/react/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/react/__tests__/Editor.test.tsx
+++ b/packages/react/__tests__/Editor.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { Editor } from '../src/Editor';
 
 jest.mock('@editorjs/editorjs', () => ({
@@ -31,6 +32,14 @@ describe('Editor', () => {
     render(<Editor placeholder="Type here" />);
     expect(EditorJS).toHaveBeenCalledWith(
       expect.objectContaining({ placeholder: 'Type here' })
+    );
+  });
+
+  it('applies custom editor class', () => {
+    render(<Editor editorClassName="my-editor" />);
+    expect(screen.getByLabelText('Rich text editor')).toHaveClass(
+      'df-editor',
+      'my-editor'
     );
   });
 });

--- a/packages/react/jest.config.cjs
+++ b/packages/react/jest.config.cjs
@@ -9,6 +9,7 @@ module.exports = {
     }
   },
   moduleNameMapper: {
-    '^(\.{1,2}/.*)\.js$': '$1'
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '\\.(css)$': '<rootDir>/__mocks__/styleMock.js'
   }
 };

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -9,9 +9,9 @@
   "files": [
     "dist"
   ],
-  "sideEffects": false,
+  "sideEffects": ["dist/editor.css"],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp src/editor.css dist/editor.css",
     "clean": "rm -rf dist",
     "test": "jest"
   },

--- a/packages/react/src/Editor.tsx
+++ b/packages/react/src/Editor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import './editor.css';
 import EditorJS, { LogLevels } from '@editorjs/editorjs';
 import Header from '@editorjs/header';
 import List from '@editorjs/list';
@@ -14,6 +15,7 @@ export function Editor({
   onChangeData,
   uploadImage,
   className,
+  editorClassName,
   ariaLabel = 'Rich text editor',
   placeholder,
   readOnly,
@@ -74,7 +76,7 @@ export function Editor({
       <div
         ref={holderRef}
         aria-label={ariaLabel}
-        style={{ border: '1px solid #ddd', borderRadius: 8, padding: 12, minHeight: 280 }}
+        className={['df-editor', editorClassName].filter(Boolean).join(' ')}
       />
     </div>
   );

--- a/packages/react/src/editor.css
+++ b/packages/react/src/editor.css
@@ -1,0 +1,6 @@
+.df-editor {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 12px;
+  min-height: 280px;
+}

--- a/packages/react/src/styles.d.ts
+++ b/packages/react/src/styles.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -13,6 +13,8 @@ export interface EditorProps {
   onChangeData?: (data: EditorJsData) => void;
   uploadImage?: UploadImageFn;
   className?: string;
+  /** Class applied to the Editor.js holder for custom styling */
+  editorClassName?: string;
   /** Accessible label for the editor region */
   ariaLabel?: string;
   /** Placeholder text shown in the first empty block */


### PR DESCRIPTION
## Summary
- move inline editor styles into new `editor.css`
- add `editorClassName` prop for custom styling
- wire up build and tests for CSS handling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adec0262548325ade4e3837bc775a3