### PR TITLE
chore: add jest tsconfig

### DIFF
--- a/packages/react/jest.config.cjs
+++ b/packages/react/jest.config.cjs
@@ -3,10 +3,14 @@ module.exports = {
   testEnvironment: 'jsdom',
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
   setupFilesAfterEnv: ['@testing-library/jest-dom'],
-  globals: {
-    'ts-jest': {
-      useESM: true
-    }
+  transform: {
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      {
+        tsconfig: './tsconfig.jest.json',
+        useESM: true
+      }
+    ]
   },
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',

--- a/packages/react/tsconfig.jest.json
+++ b/packages/react/tsconfig.jest.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["src", "__tests__"]
+}


### PR DESCRIPTION
## Summary
- create dedicated TypeScript config for Jest with proper types
- update Jest config to use new tsconfig and remove deprecated globals setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adf0f2d2748325aae72dd932f4835c