### PR TITLE
docs: add comprehensive project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,33 @@
 # DraftForge
 
-A lightweight, stack-agnostic library for **web-native rich text authoring, live preview, and delegated PDF export**.
+DraftForge provides building blocks for **web‑native rich‑text authoring, live preview, and delegated PDF export**.
+It packages a set of client‑side components and a Rails engine that work together
+or independently to render trusted HTML and deliver PDF exports.
 
-This repository hosts two independent packages:
+## Packages
 
-- `packages/react` — React components built on **Editor.js**: `Editor`, `Preview`, plus helpers for HTML rendering and export delegation.
-- `packages/rails` — Rails engine (`draft_forge`) exposing `/draftforge/exports` for async HTML or Editor.js JSON → PDF via **Grover** (Puppeteer). Includes server-side HTML sanitization and Active Storage delivery.
+This repository hosts two packages:
 
-Each package can be used on its own or combined. Refer to their READMEs for setup and configuration:
+- `packages/react` – React components built on **Editor.js**: `Editor`,
+  `Preview`, `renderToHtml`, and `exportDocument` for delegating PDF export.
+- `packages/rails` – Rails engine (`draft_forge`) exposing `/draft_forge` endpoints
+  for async HTML or Editor.js JSON → PDF via **Grover** (Puppeteer). Includes
+  server‑side HTML sanitization and Active Storage delivery.
 
-- [React components](packages/react/README.md)
-- [Rails engine](packages/rails/README.md)
+For deeper package documentation, see the [React README](packages/react/README.md)
+and the [Rails README](packages/rails/README.md). A high‑level overview lives in
+[`docs/overview.md`](docs/overview.md).
+
+## Quick Start
+
+1. Install the package(s) you need and follow their README instructions.
+2. Use the React `Editor` to collect Editor.js JSON data or provide your own payload.
+3. Delegate PDF generation to a backend service – the Rails engine supplies a ready‑made implementation.
 
 ## Development
 
-This repository is a small monorepo. Each package lives in isolation and has
-its own build and test tooling. To work on the code locally, install the
+This repository is a small monorepo. Each package lives in isolation and has its
+own build and test tooling. To work on the code locally, install the
 dependencies for the package you're touching and run its test suite:
 
 - **React package**
@@ -32,7 +44,12 @@ dependencies for the package you're touching and run its test suite:
   bundle exec rspec
   ```
 
+## License
+
+DraftForge is released under the [MIT License](packages/rails/MIT-LICENSE).
+
 ## Notes
 
-- Harden for production: authN/Z, payload limits, stricter Sanitize config, CSP headers, long-running queue.
+- Harden for production: authN/Z, payload limits, stricter Sanitize config,
+  CSP headers, long‑running queue.
 - You can extend the block renderer and styles to match product typography/layout.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,58 @@
+# DraftForge Overview
+
+DraftForge supplies end‑to‑end building blocks for web‑native rich‑text workflows.
+It combines a modern client authoring experience with a server‑side pipeline for
+rendering trusted HTML and exporting PDFs.
+
+## Packages
+
+The repository hosts two packages that can be used together or separately:
+
+### React Components (`packages/react`)
+
+Reusable components and helpers for building authoring interfaces.
+
+- **Editor** – block‑based editor powered by [Editor.js](https://editorjs.io).
+- **Preview** – client‑side HTML preview for Editor.js data.
+- **renderToHtml** – helper for server‑side rendering.
+- **exportDocument** – delegates PDF generation to a backend service.
+
+See [React package README](../packages/react/README.md) for installation and usage.
+
+### Rails Engine (`packages/rails`)
+
+A Rails engine that exposes endpoints and service objects for creating and
+fetching PDF exports. It sanitizes incoming HTML, stores rendered files with
+Active Storage, and uses [Grover](https://github.com/Studiosity/grover) for
+headless Chrome rendering.
+
+See [Rails package README](../packages/rails/README.md) for setup details.
+
+## Quick Start
+
+1. **Choose your frontend** – use the React components or roll your own client
+   that produces Editor.js JSON.
+2. **Expose an export service** – mount the Rails engine or implement a custom
+   HTTP endpoint that accepts the exported JSON and responds with a polling URL.
+3. **Delegate export** – call `exportDocument` from the client or trigger
+   `DraftForge::CreateExport` on the server to generate a PDF asynchronously.
+
+## Development
+
+Each package lives in isolation. Install dependencies and run tests in the
+package you are modifying:
+
+```bash
+# React components
+cd packages/react
+npm test
+
+# Rails engine
+cd packages/rails
+bundle exec rspec
+```
+
+## License
+
+DraftForge is released under the MIT License. See the [LICENSE](../packages/rails/MIT-LICENSE)
+file for the full text.


### PR DESCRIPTION
## Summary
- document repo structure and workflow in new `docs/overview.md`
- expand root README with package descriptions, quick start, and license info

## Testing
- `cd packages/react && npm test`
- `cd packages/rails && bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_68ae3168b4788325be9e9dd325e283e1