### PR TITLE
Switch to Slate editor with collaborative support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ or independently to render trusted HTML and deliver PDF exports.
 
 This repository hosts two packages:
 
-- `packages/react` – React components built on **Editor.js**: `Editor`,
+- `packages/react` – React components built on **Slate** with optional collaborative editing: `Editor`,
   `Preview`, `renderToHtml`, and `exportDocument` for delegating PDF export.
 - `packages/rails` – Rails engine (`draft_forge`) exposing `/draft_forge` endpoints
   for async HTML or Editor.js JSON → PDF via **Grover** (Puppeteer). Includes

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -2,7 +2,7 @@
 
 Standalone React components for rich-text authoring with delegated PDF export. Includes:
 
-- **Editor** – block-based editor powered by Editor.js
+- **Editor** – rich-text editor powered by Slate with optional collaborative editing and configurable header
 - **Preview** – client-side HTML preview of Editor.js data
 - **renderToHtml** – helper for server-side rendering
 - **exportDocument** – delegates export to a backend service
@@ -54,11 +54,13 @@ import { Editor, Preview, exportDocument } from 'draftforge';
 import 'draftforge/dist/editor.css';
 
 export default function Composer() {
-  const [data, setData] = useState({ blocks: [] });
+  const [value, setValue] = useState([
+    { type: 'paragraph', children: [{ text: '' }] }
+  ]);
 
   const handleExport = async () => {
     const url = await exportDocument({
-      data,
+      data: { blocks: [] },
       filename: 'document.pdf',
       exportUrl: '/exports',
       pollBaseUrl: '/exports'
@@ -68,8 +70,14 @@ export default function Composer() {
 
   return (
     <>
-      <Editor initialData={data} onChangeData={setData} />
-      <Preview data={data} />
+      <Editor
+        initialValue={value}
+        onChangeValue={setValue}
+        header={<h1>My Document</h1>}
+        collaborative
+        collabUrl="ws://localhost:1234"
+      />
+      <Preview data={{ blocks: [] }} />
       <button onClick={handleExport}>Export PDF</button>
     </>
   );

--- a/packages/react/__tests__/Editor.test.tsx
+++ b/packages/react/__tests__/Editor.test.tsx
@@ -2,20 +2,6 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Editor } from '../src/Editor';
 
-jest.mock('@editorjs/editorjs', () => ({
-  __esModule: true,
-  default: jest.fn().mockImplementation(() => ({ destroy: jest.fn() })),
-  LogLevels: { ERROR: 'ERROR' }
-}));
-
-jest.mock('@editorjs/header', () => ({ __esModule: true, default: function () {} }));
-jest.mock('@editorjs/list', () => ({ __esModule: true, default: function () {} }));
-jest.mock('@editorjs/checklist', () => ({ __esModule: true, default: function () {} }));
-jest.mock('@editorjs/table', () => ({ __esModule: true, default: function () {} }));
-jest.mock('@editorjs/quote', () => ({ __esModule: true, default: function () {} }));
-jest.mock('@editorjs/code', () => ({ __esModule: true, default: function () {} }));
-jest.mock('@editorjs/image', () => ({ __esModule: true, default: function () {} }));
-
 describe('Editor', () => {
   it('uses provided aria-label', () => {
     render(<Editor ariaLabel="Custom label" />);
@@ -27,20 +13,17 @@ describe('Editor', () => {
     expect(screen.getByLabelText('Rich text editor')).toBeTruthy();
   });
 
-  it('passes placeholder to Editor.js', () => {
-    const EditorJS = require('@editorjs/editorjs').default as jest.Mock;
-    render(<Editor placeholder="Type here" />);
-    expect(EditorJS).toHaveBeenCalledWith(
-      expect.objectContaining({ placeholder: 'Type here' })
-    );
-  });
-
   it('applies custom editor class', () => {
     render(<Editor editorClassName="my-editor" />);
     expect(screen.getByLabelText('Rich text editor')).toHaveClass(
       'df-editor',
       'my-editor'
     );
+  });
+
+  it('renders provided header', () => {
+    render(<Editor header={<h1>Header</h1>} />);
+    expect(screen.getByText('Header')).toBeInTheDocument();
   });
 });
 

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,22 +1,21 @@
 {
   "name": "draftforge",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "draftforge",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "@editorjs/checklist": "^1.3.0",
-        "@editorjs/code": "^2.8.0",
-        "@editorjs/editorjs": "^2.29.0",
-        "@editorjs/header": "^2.8.1",
-        "@editorjs/image": "^2.9.0",
-        "@editorjs/list": "^1.9.0",
-        "@editorjs/quote": "^2.5.0",
-        "@editorjs/table": "^2.2.1",
-        "dompurify": "^3.1.6"
+        "@slate-yjs/core": "^1.0.2",
+        "@slate-yjs/react": "^1.1.0",
+        "dompurify": "^3.1.6",
+        "slate": "^0.117.0",
+        "slate-history": "^0.115.0",
+        "slate-react": "^0.117.0",
+        "y-websocket": "^3.0.0",
+        "yjs": "^13.6.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",
@@ -561,116 +560,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@codexteam/icons": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@codexteam/icons/-/icons-0.3.3.tgz",
-      "integrity": "sha512-cp7mkZPgmBuSxigTm3Vb+DtVHYeX7qXfQd7o05vcLD8Ag5WvRlol2QSn5P10k0CDAJwmkH9nQGQLBycErS9lsQ==",
-      "license": "MIT"
-    },
-    "node_modules/@editorjs/checklist": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@editorjs/checklist/-/checklist-1.6.0.tgz",
-      "integrity": "sha512-hRNP36DInr73mSK3noHBQeoQb7DA12ANfqTXufEkTgQzx+k4mRJ0HdeGukTIR4JbwjHJ9ecUBnnQqIEGnxCFEg==",
-      "license": "MIT",
-      "dependencies": {
-        "@codexteam/icons": "^0.3.0"
-      }
-    },
-    "node_modules/@editorjs/code": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@editorjs/code/-/code-2.9.3.tgz",
-      "integrity": "sha512-nXUrK3CjhpubvShYtcbkpZ9SU15IYwmJOsWZrlWYSzy9unZBRQthii6eABndsCtODzzV0yiSKmTp00RQkFow3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@codexteam/icons": "^0.3.2"
-      }
-    },
-    "node_modules/@editorjs/dom": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@editorjs/dom/-/dom-0.0.5.tgz",
-      "integrity": "sha512-SZ78Gwpkp3EUhjBIp0lSojeQ35V9acF8SubJsMeOH/vlOUE40GOnvvwWZnF05lO7bIB0dOHhhJy4N7IIAWxP2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@editorjs/helpers": "^0.0.4"
-      }
-    },
-    "node_modules/@editorjs/editorjs": {
-      "version": "2.30.8",
-      "resolved": "https://registry.npmjs.org/@editorjs/editorjs/-/editorjs-2.30.8.tgz",
-      "integrity": "sha512-ClFuxI1qZTfXPJTacQfsJtOUP6bKoIe6BQNdAvGsDTDVwMnZEzoaSOwvUpdZEE56xppVfQueNK/1MElV9SJKHg==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@editorjs/header": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/@editorjs/header/-/header-2.8.8.tgz",
-      "integrity": "sha512-bsMSs34u2hoi0UBuRoc5EGWXIFzJiwYgkFUYQGVm63y5FU+s8zPBmVx5Ip2sw1xgs0fqfDROqmteMvvmbCy62w==",
-      "license": "MIT",
-      "dependencies": {
-        "@codexteam/icons": "^0.0.5",
-        "@editorjs/editorjs": "^2.29.1"
-      }
-    },
-    "node_modules/@editorjs/header/node_modules/@codexteam/icons": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@codexteam/icons/-/icons-0.0.5.tgz",
-      "integrity": "sha512-s6H2KXhLz2rgbMZSkRm8dsMJvyUNZsEjxobBEg9ztdrb1B2H3pEzY6iTwI4XUPJWJ3c3qRKwV4TrO3J5jUdoQA==",
-      "license": "MIT"
-    },
-    "node_modules/@editorjs/helpers": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@editorjs/helpers/-/helpers-0.0.4.tgz",
-      "integrity": "sha512-ieg3dzo2m1/ELze/RMNADiAiC5amXxIlVXoJ5vvXITOu/p/dPsrF+Oi3h5gBYvtGk9vg5LJUSG5YWU0tBUO1tw==",
-      "license": "MIT"
-    },
-    "node_modules/@editorjs/image": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@editorjs/image/-/image-2.10.3.tgz",
-      "integrity": "sha512-ekCsGICZOIdghF/U2T34H7CItqaWAoJDXbkRD+x8l/LIo/7Ozf7KovYm21qz+CluArgV4RurVFHqwlz+O0vfJA==",
-      "license": "MIT",
-      "dependencies": {
-        "@codexteam/icons": "^0.3.0"
-      }
-    },
-    "node_modules/@editorjs/list": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@editorjs/list/-/list-1.10.0.tgz",
-      "integrity": "sha512-zXCHaNcIscpefnteBOS3x+98f/qBgEVsv+OvtKoTDZipMNqck2uVG+X2qMQr8xcwtJrj9ySX54lUac9FDlAHnA==",
-      "license": "MIT",
-      "dependencies": {
-        "@codexteam/icons": "^0.0.4"
-      }
-    },
-    "node_modules/@editorjs/list/node_modules/@codexteam/icons": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@codexteam/icons/-/icons-0.0.4.tgz",
-      "integrity": "sha512-V8N/TY2TGyas4wLrPIFq7bcow68b3gu8DfDt1+rrHPtXxcexadKauRJL6eQgfG7Z0LCrN4boLRawR4S9gjIh/Q==",
-      "license": "MIT"
-    },
-    "node_modules/@editorjs/quote": {
-      "version": "2.7.6",
-      "resolved": "https://registry.npmjs.org/@editorjs/quote/-/quote-2.7.6.tgz",
-      "integrity": "sha512-D01KUMSDj2r+6Z+xjDkQqI+y6URpeHCvj0+P4pah+GtkG040lWjFb2H4pgHFXuol2cbfyAoraYSw85fuPheCvw==",
-      "license": "MIT",
-      "dependencies": {
-        "@codexteam/icons": "^0.3.2",
-        "@editorjs/dom": "^0.0.5"
-      }
-    },
-    "node_modules/@editorjs/table": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@editorjs/table/-/table-2.4.5.tgz",
-      "integrity": "sha512-pF48R2wc5m0c+N+RjtCLXBGZd23Rl7EjfSFpmcSViwNsu5RwMgYGrEiQ8mzVh98mbvYQwXm/NYBi9DEUUs970A==",
-      "license": "MIT",
-      "dependencies": {
-        "@codexteam/icons": "^0.0.6"
-      }
-    },
-    "node_modules/@editorjs/table/node_modules/@codexteam/icons": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@codexteam/icons/-/icons-0.0.6.tgz",
-      "integrity": "sha512-L7Q5PET8PjKcBT5wp7VR+FCjwCi5PUp7rd/XjsgQ0CI5FJz0DphyHGRILMuDUdCW2MQT9NHbVr4QP31vwAkS/A==",
-      "license": "MIT"
-    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1064,6 +953,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@juggle/resize-observer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1089,6 +984,36 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@slate-yjs/core": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@slate-yjs/core/-/core-1.0.2.tgz",
+      "integrity": "sha512-X0hLFJbQu9c1ItWBaNuEn0pqcXYK76KCp8C4Gvy/VaTQVMo1VgAb2WiiJ0Je/AyuIYEPPSTNVOcyrGHwgA7e6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "y-protocols": "^1.0.5"
+      },
+      "peerDependencies": {
+        "slate": ">=0.70.0",
+        "yjs": "^13.5.29"
+      }
+    },
+    "node_modules/@slate-yjs/react": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@slate-yjs/react/-/react-1.1.0.tgz",
+      "integrity": "sha512-lGpEJLwThMPVZ+beqsoBowwBO2egu7K8ow+TOM4k2Liz9/dD1H9/ZNrdfZkPVSYT9NmgFm4dYc187t5GC4Wd6g==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.0",
+        "y-protocols": "^1.0.5"
+      },
+      "peerDependencies": {
+        "@slate-yjs/core": "^1.0.0",
+        "react": ">=16.8.0",
+        "slate": ">=0.70.0",
+        "slate-react": ">=0.70.0",
+        "yjs": "^13.5.29"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -1991,6 +1916,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2245,6 +2176,19 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/direction": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
+      "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
+      "license": "MIT",
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -2953,6 +2897,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -3168,6 +3122,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-hotkey": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.2.0.tgz",
+      "integrity": "sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw==",
+      "license": "MIT"
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -3206,6 +3166,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -3354,6 +3324,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -4497,6 +4477,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/lib0": {
+      "version": "0.2.114",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
+      "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -4516,6 +4517,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -5306,6 +5313,15 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "compute-scroll-into-view": "^3.0.2"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -5471,6 +5487,64 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slate": {
+      "version": "0.117.2",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.117.2.tgz",
+      "integrity": "sha512-vHfMHrb8WJ6TFfl7yLXT+UlTzdbUQHpAfdGV0tJfECvbRMAOwAKkjgtAMI8FBmJ1t6BKUgX3ybXk3Y2JxQ2R1w==",
+      "license": "MIT",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "tiny-warning": "^1.0.3"
+      }
+    },
+    "node_modules/slate-dom": {
+      "version": "0.118.1",
+      "resolved": "https://registry.npmjs.org/slate-dom/-/slate-dom-0.118.1.tgz",
+      "integrity": "sha512-D6J0DF9qdJrXnRDVhYZfHzzpVxzqKRKFfS0Wcin2q0UC+OnQZ0lbCGJobatVbisOlbSe7dYFHBp9OZ6v1lEcbQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
+      },
+      "peerDependencies": {
+        "slate": ">=0.99.0"
+      }
+    },
+    "node_modules/slate-history": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.115.0.tgz",
+      "integrity": "sha512-QdUm9aVyQFz6JG4a84Z6Um+tJpZJmsh9bjXwTVTvYiN4rdKbqL6+/4HT94on1WYxe10Q4vY6mA6BCpoYxgF3tQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "slate": ">=0.114.3"
+      }
+    },
+    "node_modules/slate-react": {
+      "version": "0.117.4",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.117.4.tgz",
+      "integrity": "sha512-9ckilyUzQS1VHJnstIpgInhcWnTDgv2Cd7m1HOQVl3zasChoapPSMftzT/wl/48grZaZYZIi4xVuzGTcFRUWFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "slate": ">=0.114.0",
+        "slate-dom": ">=0.116.0"
       }
     },
     "node_modules/source-map": {
@@ -5663,6 +5737,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
+      "license": "MIT"
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -5900,6 +5986,15 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -6149,6 +6244,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y-protocols": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
+      "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
+    "node_modules/y-websocket": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/y-websocket/-/y-websocket-3.0.0.tgz",
+      "integrity": "sha512-mUHy7AzkOZ834T/7piqtlA8Yk6AchqKqcrCXjKW8J1w2lPtRDjz8W5/CvXz9higKAHgKRKqpI3T33YkRFLkPtg==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.102",
+        "y-protocols": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.5.6"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -6193,6 +6329,23 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.27",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
+      "integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/yocto-queue": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,15 +20,14 @@
     "react-dom": ">=18"
   },
   "dependencies": {
-    "@editorjs/checklist": "^1.3.0",
-    "@editorjs/code": "^2.8.0",
-    "@editorjs/editorjs": "^2.29.0",
-    "@editorjs/header": "^2.8.1",
-    "@editorjs/image": "^2.9.0",
-    "@editorjs/list": "^1.9.0",
-    "@editorjs/quote": "^2.5.0",
-    "@editorjs/table": "^2.2.1",
-    "dompurify": "^3.1.6"
+    "dompurify": "^3.1.6",
+    "slate": "^0.117.0",
+    "slate-react": "^0.117.0",
+    "slate-history": "^0.115.0",
+    "@slate-yjs/core": "^1.0.2",
+    "@slate-yjs/react": "^1.1.0",
+    "yjs": "^13.6.0",
+    "y-websocket": "^3.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",

--- a/packages/react/src/editor.css
+++ b/packages/react/src/editor.css
@@ -4,3 +4,7 @@
   padding: 12px;
   min-height: 280px;
 }
+
+.df-editor-header {
+  margin-bottom: 8px;
+}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,6 +1,5 @@
-import type EditorJS from '@editorjs/editorjs';
-
-export type UploadImageFn = (file: File) => Promise<string>;
+import type { Descendant } from 'slate';
+import type { ReactNode } from 'react';
 
 export interface EditorJsBlock {
   /** Block type identifier, e.g. `paragraph` */
@@ -19,20 +18,22 @@ export interface EditorJsData {
 }
 
 export interface EditorProps {
-  initialData?: EditorJsData;
-  onChangeData?: (data: EditorJsData) => void;
-  uploadImage?: UploadImageFn;
+  initialValue?: Descendant[];
+  onChangeValue?: (value: Descendant[]) => void;
+  header?: ReactNode;
   className?: string;
-  /** Class applied to the Editor.js holder for custom styling */
+  /** Class applied to the editor element for custom styling */
   editorClassName?: string;
   /** Accessible label for the editor region */
   ariaLabel?: string;
-  /** Placeholder text shown in the first empty block */
+  /** Placeholder text shown when empty */
   placeholder?: string;
   /** Toggle read-only mode */
   readOnly?: boolean;
-  /** Callback once the Editor.js instance is ready */
-  onReady?: (editor: EditorJS) => void;
+  /** Enable collaborative editing via Yjs */
+  collaborative?: boolean;
+  /** Websocket endpoint for collaborative editing */
+  collabUrl?: string;
 }
 
 export interface PreviewProps {


### PR DESCRIPTION
## Summary
- replace Editor.js implementation with Slate, enabling collaborative editing via Yjs
- add configurable header support to the React editor component
- document new Slate-based editor usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af16aee2248325a887fac07c6a697d