### PR TITLE
feat: support non-editable blocks

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -2,7 +2,7 @@
 
 Standalone React components for rich-text authoring with delegated PDF export. Includes:
 
-- **Editor** – rich-text editor powered by Slate with optional collaborative editing and configurable header
+- **Editor** – rich-text editor powered by Slate with optional collaborative editing, configurable header, and support for non-editable blocks via an `editable` flag
 - **Preview** – client-side HTML preview of Editor.js data
 - **renderToHtml** – helper for server-side rendering
 - **exportDocument** – delegates export to a backend service
@@ -56,7 +56,7 @@ import 'draftforge/dist/editor.css';
 export default function Composer() {
   const [value, setValue] = useState([
     { type: 'paragraph', children: [{ text: '' }] }
-  ]);
+  ]); // blocks may include `editable: false` to lock sections
 
   const handleExport = async () => {
     const url = await exportDocument({

--- a/packages/react/__tests__/Editor.test.tsx
+++ b/packages/react/__tests__/Editor.test.tsx
@@ -25,5 +25,17 @@ describe('Editor', () => {
     render(<Editor header={<h1>Header</h1>} />);
     expect(screen.getByText('Header')).toBeInTheDocument();
   });
+
+  it('respects editable flag on blocks', () => {
+    render(
+      <Editor
+        initialValue={[
+          { type: 'paragraph', editable: false, children: [{ text: 'Locked' }] } as any,
+        ]}
+      />
+    );
+    const el = screen.getByText('Locked').closest('[contenteditable]');
+    expect(el).toHaveAttribute('contenteditable', 'false');
+  });
 });
 

--- a/packages/react/src/Editor.tsx
+++ b/packages/react/src/Editor.tsx
@@ -3,9 +3,16 @@ import {
   useMemo,
   useState,
   useEffect,
+  useCallback,
 } from 'react';
 import { createEditor, Descendant } from 'slate';
-import { Slate, Editable, withReact } from 'slate-react';
+import {
+  Slate,
+  Editable,
+  withReact,
+  DefaultElement,
+  type RenderElementProps,
+} from 'slate-react';
 import { withHistory } from 'slate-history';
 import { withYjs, YjsEditor } from '@slate-yjs/core';
 import * as Y from 'yjs';
@@ -47,6 +54,19 @@ export function Editor({
     return e;
   }, [collaborative, sharedType]);
 
+  const renderElement = useCallback((props: RenderElementProps) => {
+    const { element } = props;
+    if ((element as any).editable === false) {
+      const attributes = {
+        ...props.attributes,
+        contentEditable: false,
+        suppressContentEditableWarning: true,
+      } as any;
+      return <DefaultElement {...props} attributes={attributes} />;
+    }
+    return <DefaultElement {...props} />;
+  }, []);
+
   useEffect(() => {
     if (collaborative && editor) {
       YjsEditor.connect(editor as any);
@@ -73,6 +93,7 @@ export function Editor({
           aria-label={ariaLabel}
           placeholder={placeholder}
           readOnly={readOnly}
+          renderElement={renderElement}
         />
       </Slate>
     </div>


### PR DESCRIPTION
## Summary
- respect `editable: false` on blocks to render read-only content in the Slate-based editor
- document the `editable` flag and note locking behavior in usage example
- cover non-editable blocks with a unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af1cbdaf108325a60c2f01181cf844