### PR TITLE
chore: remove Editor.js references

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository hosts two packages:
 - `packages/react` – React components built on **Slate** with optional collaborative editing: `Editor`,
   `Preview`, `renderToHtml`, and `exportDocument` for delegating PDF export.
 - `packages/rails` – Rails engine (`draft_forge`) exposing `/draft_forge` endpoints
-  for async HTML or Editor.js JSON → PDF via **Grover** (Puppeteer). Includes
+  for async HTML → PDF via **Grover** (Puppeteer). Includes
   server‑side HTML sanitization and Active Storage delivery.
 
 For deeper package documentation, see the [React README](packages/react/README.md)
@@ -21,7 +21,7 @@ and the [Rails README](packages/rails/README.md). A high‑level overview lives 
 ## Quick Start
 
 1. Install the package(s) you need and follow their README instructions.
-2. Use the React `Editor` to collect Editor.js JSON data or provide your own payload.
+2. Use the React `Editor` to collect block JSON data or provide your own payload.
 3. Delegate PDF generation to a backend service – the Rails engine supplies a ready‑made implementation.
 
 ## Development

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,7 +13,7 @@ The repository hosts two packages that can be used together or separately:
 Reusable components and helpers for building authoring interfaces.
 
 - **Editor** – headless editor powered by Slate with an inline formatting toolbar.
-- **Preview** – client‑side HTML preview for Editor.js data.
+- **Preview** – client‑side HTML preview for block data.
 - **renderToHtml** – helper for server‑side rendering.
 - **exportDocument** – delegates PDF generation to a backend service.
 
@@ -35,7 +35,7 @@ See [Rails package README](../packages/rails/README.md) for setup details.
 ## Quick Start
 
 1. **Choose your frontend** – use the React components or roll your own client
-   that produces Editor.js JSON.
+   that produces block JSON.
 2. **Expose an export service** – mount the Rails engine or implement a custom
    HTTP endpoint that accepts the exported JSON and responds with a polling URL.
 3. **Delegate export** – call `exportDocument` from the client or trigger

--- a/packages/rails/README.md
+++ b/packages/rails/README.md
@@ -1,6 +1,6 @@
 # draft_forge
 
-Rails engine for exporting HTML or Editor.js JSON to PDF. Can be paired with any front-end or used standalone.
+Rails engine for exporting HTML or block JSON to PDF. Can be paired with any front-end or used standalone.
 
 Requires Ruby 3.1 or higher. See [CHANGELOG](CHANGELOG.md) for release notes.
 

--- a/packages/rails/app/controllers/draft_forge/exports_controller.rb
+++ b/packages/rails/app/controllers/draft_forge/exports_controller.rb
@@ -6,7 +6,7 @@ module DraftForge
 
     def create
       html = if params[:content_json].present?
-               EditorJsRenderer.call(params[:content_json])
+               BlockJsonRenderer.call(params[:content_json])
              else
                params[:content_html].to_s
              end

--- a/packages/rails/app/services/draft_forge/block_json_renderer.rb
+++ b/packages/rails/app/services/draft_forge/block_json_renderer.rb
@@ -3,8 +3,8 @@
 require 'json'
 
 module DraftForge
-  # Convert Editor.js data to basic HTML
-class EditorJsRenderer
+  # Convert block JSON data to basic HTML
+  class BlockJsonRenderer
     def self.call(data)
       data = parse(data)
       blocks = data.fetch('blocks', [])

--- a/packages/rails/app/services/draft_forge/create_export.rb
+++ b/packages/rails/app/services/draft_forge/create_export.rb
@@ -8,7 +8,7 @@ module DraftForge
         return
       end
       html = if content_json
-               EditorJsRenderer.call(content_json)
+               BlockJsonRenderer.call(content_json)
              else
                content_html.to_s
              end

--- a/packages/rails/spec/block_json_renderer_spec.rb
+++ b/packages/rails/spec/block_json_renderer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
-require_relative '../app/services/draft_forge/editor_js_renderer'
+require_relative '../app/services/draft_forge/block_json_renderer'
 
-RSpec.describe DraftForge::EditorJsRenderer do
+RSpec.describe DraftForge::BlockJsonRenderer do
   it 'renders basic blocks to html' do
     data = {
       'blocks' => [

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -3,7 +3,7 @@
 Standalone React helpers for rich-text authoring with delegated PDF export. Includes:
 
 - **Editor** – headless rich-text editor powered by Slate with optional collaborative editing, an inline formatting toolbar, and support for non-editable blocks via an `editable` flag
-- **Preview** – client-side HTML preview of Editor.js data
+- **Preview** – client-side HTML preview of block data
 - **renderToHtml** – helper for server-side rendering
 - **exportDocument** – delegates export to a backend service
 
@@ -75,7 +75,7 @@ export default function Composer() {
 }
 ```
 
-Use with any backend capable of accepting Editor.js JSON and returning a URL
+Use with any backend capable of accepting block JSON and returning a URL
 to a rendered PDF when ready.
 
 ### Long-running exports
@@ -100,7 +100,7 @@ The backoff reduces network chatter when exporting very large PDFs (100+ pages).
 ### Pagination
 
 `Preview` and `renderToHtml` accept optional `page` and `pageSize` parameters to
-help work with very large Editor.js datasets. Render only a slice of blocks for
+help work with very large datasets. Render only a slice of blocks for
 lightweight previews or server-side rendering:
 
 ```tsx
@@ -115,5 +115,5 @@ like Google Docs.
 ### Efficient previews
 
 `Preview` sanitizes the generated HTML on an idle callback so rendering huge
-Editor.js datasets doesn't lock up the UI. The content appears once the browser
+datasets doesn't lock up the UI. The content appears once the browser
 has time to process it, keeping previews responsive even for 100+ page drafts.

--- a/packages/react/src/editorjs-checklist.d.ts
+++ b/packages/react/src/editorjs-checklist.d.ts
@@ -1,1 +1,0 @@
-declare module '@editorjs/checklist';

--- a/packages/react/src/exportDocument.ts
+++ b/packages/react/src/exportDocument.ts
@@ -1,7 +1,7 @@
 import type { ExportOptions } from './types';
 
 /**
- * Delegate export of Editor.js data to a backend service.
+ * Delegate export of document data to a backend service.
  * Returns the download URL when ready.
  */
 export async function exportDocument({

--- a/packages/react/src/renderToHtml.ts
+++ b/packages/react/src/renderToHtml.ts
@@ -1,8 +1,8 @@
-import type { EditorJsData, RenderOptions } from './types';
+import type { DocumentData, RenderOptions } from './types';
 
-/** Minimal Renderer: Editor.js JSON -> HTML string */
+/** Minimal Renderer: block JSON -> HTML string */
 export function renderToHtml(
-  data: EditorJsData,
+  data: DocumentData,
   opts: RenderOptions = {}
 ): string {
   if (!data || !Array.isArray(data.blocks)) return '';

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,6 +1,6 @@
 import type { Descendant } from 'slate';
 
-export interface EditorJsBlock {
+export interface Block {
   /** Block type identifier, e.g. `paragraph` */
   type: string;
   /** Arbitrary data specific to the block type */
@@ -10,9 +10,9 @@ export interface EditorJsBlock {
   [key: string]: any;
 }
 
-export interface EditorJsData {
+export interface DocumentData {
   time?: number;
-  blocks: EditorJsBlock[];
+  blocks: Block[];
   version?: string;
 }
 
@@ -36,7 +36,7 @@ export interface EditorProps {
 export type UseEditorOptions = Pick<EditorProps, 'initialValue' | 'onChangeValue' | 'collaborative' | 'collabUrl'>;
 
 export interface PreviewProps {
-  data: EditorJsData;
+  data: DocumentData;
   className?: string;
   /** Page number to render when working with large datasets */
   page?: number;
@@ -50,7 +50,7 @@ export interface RenderOptions {
 }
 
 export interface ExportOptions {
-  data: EditorJsData;
+  data: DocumentData;
   filename?: string;
   exportUrl: string;    // POST endpoint
   pollBaseUrl: string;  // GET base, i.e. `${pollBaseUrl}/${id}`


### PR DESCRIPTION
## Summary
- replace Editor.js mentions with generic block JSON across docs
- rename server-side renderer to `BlockJsonRenderer`
- rename React types and comments to drop Editor.js wording

## Testing
- `npm test`
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_68af38e7fbe08325af11eef031d05cf8