### PR TITLE
refactor: rename DocumentData to Document

### DIFF
--- a/packages/react/src/renderToHtml.ts
+++ b/packages/react/src/renderToHtml.ts
@@ -1,8 +1,8 @@
-import type { DocumentData, RenderOptions } from './types';
+import type { Document, RenderOptions } from './types';
 
 /** Minimal Renderer: block JSON -> HTML string */
 export function renderToHtml(
-  data: DocumentData,
+  data: Document,
   opts: RenderOptions = {}
 ): string {
   if (!data || !Array.isArray(data.blocks)) return '';

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -10,7 +10,7 @@ export interface Block {
   [key: string]: any;
 }
 
-export interface DocumentData {
+export interface Document {
   time?: number;
   blocks: Block[];
   version?: string;
@@ -36,7 +36,7 @@ export interface EditorProps {
 export type UseEditorOptions = Pick<EditorProps, 'initialValue' | 'onChangeValue' | 'collaborative' | 'collabUrl'>;
 
 export interface PreviewProps {
-  data: DocumentData;
+  data: Document;
   className?: string;
   /** Page number to render when working with large datasets */
   page?: number;
@@ -50,7 +50,7 @@ export interface RenderOptions {
 }
 
 export interface ExportOptions {
-  data: DocumentData;
+  data: Document;
   filename?: string;
   exportUrl: string;    // POST endpoint
   pollBaseUrl: string;  // GET base, i.e. `${pollBaseUrl}/${id}`


### PR DESCRIPTION
## Summary
- rename DocumentData type to Document and update dependent APIs

## Testing
- `cd packages/react && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af4bb669488325a28f6ecb692c7e02