### PR TITLE
feat: add image media support with contextual toolbar

### DIFF
--- a/packages/react/__tests__/Editor.test.tsx
+++ b/packages/react/__tests__/Editor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Editor } from '../src/Editor';
 
@@ -30,5 +30,46 @@ describe('Editor', () => {
     expect(el).toHaveAttribute('contenteditable', 'false');
   });
 
+  it('inserts image via toolbar', async () => {
+    const promptSpy = jest.spyOn(window, 'prompt').mockReturnValue('http://img');
+    render(<Editor initialValue={[{ type: 'paragraph', children: [{ text: 'hi' }] } as any]} />);
+    const editable = screen.getByLabelText('Rich text editor');
+    const textNode = editable.querySelector('span')!.firstChild as Text;
+    const range = document.createRange();
+    range.selectNodeContents(textNode);
+    (range as any).getBoundingClientRect = () => ({
+      top: 0,
+      left: 0,
+      width: 10,
+      height: 10,
+      bottom: 0,
+      right: 0,
+    });
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+    fireEvent.mouseUp(editable);
+    const addBtn = await screen.findByTestId('add-image');
+    fireEvent.mouseDown(addBtn);
+    expect(await screen.findByTestId('image')).toHaveAttribute('src', 'http://img');
+    promptSpy.mockRestore();
+  });
+
+  it('resizes image via toolbar slider', async () => {
+    render(
+      <Editor
+        initialValue={[
+          { type: 'image', url: 'http://img', width: 100, children: [{ text: '' }] } as any,
+        ]}
+      />
+    );
+    const img = screen.getByTestId('image');
+    fireEvent.click(img);
+    const slider = screen.getByTestId('resize-slider');
+    fireEvent.change(slider, { target: { value: '300' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('image')).toHaveStyle({ width: '300px' });
+    });
+  });
 });
 

--- a/packages/react/src/InlineToolbar.tsx
+++ b/packages/react/src/InlineToolbar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useSlate } from 'slate-react';
-import { Editor as SlateEditor } from 'slate';
+import { Editor as SlateEditor, Transforms, Element as SlateElement } from 'slate';
 
 interface ToolbarProps {
   position: { top: number; left: number } | null;
@@ -19,6 +19,18 @@ export const InlineToolbar: React.FC<ToolbarProps> = ({ position, onRequestClose
     } else {
       SlateEditor.addMark(editor, format, true);
     }
+    onRequestClose();
+  };
+
+  const imageEntry = SlateEditor.above(editor, {
+    match: n => SlateElement.isElement(n) && (n as any).type === 'image',
+  });
+
+  const insertImage = () => {
+    const url = window.prompt('Enter image URL');
+    if (!url) return;
+    const image = { type: 'image', url, width: 200, children: [{ text: '' }] } as any;
+    Transforms.insertNodes(editor, image);
     onRequestClose();
   };
 
@@ -47,24 +59,50 @@ export const InlineToolbar: React.FC<ToolbarProps> = ({ position, onRequestClose
       }}
       data-testid="inline-toolbar"
     >
-      <button
-        style={buttonStyle}
-        onMouseDown={e => {
-          e.preventDefault();
-          toggleMark('bold');
-        }}
-      >
-        <strong>B</strong>
-      </button>
-      <button
-        style={buttonStyle}
-        onMouseDown={e => {
-          e.preventDefault();
-          toggleMark('italic');
-        }}
-      >
-        <em>I</em>
-      </button>
+      {imageEntry ? (
+        <input
+          type="range"
+          min={50}
+          max={800}
+          value={(imageEntry[0] as any).width || 200}
+          onChange={e => {
+            const w = parseInt(e.target.value, 10);
+            Transforms.setNodes(editor, { width: w } as any, { at: imageEntry[1] });
+          }}
+          data-testid="resize-slider"
+        />
+      ) : (
+        <>
+          <button
+            style={buttonStyle}
+            onMouseDown={e => {
+              e.preventDefault();
+              toggleMark('bold');
+            }}
+          >
+            <strong>B</strong>
+          </button>
+          <button
+            style={buttonStyle}
+            onMouseDown={e => {
+              e.preventDefault();
+              toggleMark('italic');
+            }}
+          >
+            <em>I</em>
+          </button>
+          <button
+            style={buttonStyle}
+            onMouseDown={e => {
+              e.preventDefault();
+              insertImage();
+            }}
+            data-testid="add-image"
+          >
+            Img
+          </button>
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- show context-aware controls in inline toolbar
- allow inserting images and resizing them
- cover image tools with new tests

## Testing
- `cd packages/react && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af4d82653883259977cfd2d0a1e4c9