### PR TITLE
refactor: combine sections into single composite editor

### DIFF
--- a/packages/react/__tests__/CompositeEditor.test.tsx
+++ b/packages/react/__tests__/CompositeEditor.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { CompositeEditor } from '../src/CompositeEditor';
+
+describe('CompositeEditor', () => {
+  it('renders sections in order and respects editability', () => {
+    render(
+      <CompositeEditor
+        sections={[
+          {
+            id: '1',
+            value: [{ type: 'paragraph', children: [{ text: 'first' }] } as any],
+          },
+          {
+            id: '2',
+            value: [{ type: 'paragraph', children: [{ text: 'second' }] } as any],
+            editable: false,
+          },
+        ]}
+      />,
+    );
+    const texts = screen.getAllByText(/first|second/);
+    expect(texts[0]).toHaveTextContent('first');
+    expect(texts[1]).toHaveTextContent('second');
+    const firstSection = screen.getByText('first').closest('[data-section-id="1"]');
+    const secondSection = screen.getByText('second').closest('[data-section-id="2"]');
+    expect(firstSection).not.toHaveAttribute('contenteditable', 'false');
+    expect(secondSection).toHaveAttribute('contenteditable', 'false');
+  });
+
+  it('allows deleting editable sections', () => {
+    render(
+      <CompositeEditor
+        sections={[
+          {
+            id: '1',
+            value: [{ type: 'paragraph', children: [{ text: 'delete me' }] } as any],
+          },
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByText('Delete'));
+    expect(screen.queryByText('delete me')).toBeNull();
+  });
+});

--- a/packages/react/src/CompositeEditor.tsx
+++ b/packages/react/src/CompositeEditor.tsx
@@ -1,0 +1,75 @@
+import { useState, useCallback, useMemo } from 'react';
+import type { CompositeEditorProps, Section } from './types';
+import type { Descendant } from 'slate';
+import { Editor } from './Editor';
+
+export function CompositeEditor({ sections, onChangeSections, className }: CompositeEditorProps) {
+  const [data, setData] = useState<Section[]>(sections);
+
+  const combinedValue = useMemo(
+    () =>
+      data.map(sec => ({
+        type: 'section',
+        sectionId: sec.id,
+        editable: sec.editable,
+        children: sec.value,
+      })),
+    [data],
+  );
+
+  const handleChange = useCallback(
+    (value: Descendant[]) => {
+      const next = (value as any[]).map(node => ({
+        id: node.sectionId as string,
+        editable: node.editable as boolean | undefined,
+        value: node.children as Descendant[],
+      }));
+      setData(next);
+      onChangeSections?.(next);
+    },
+    [onChangeSections],
+  );
+
+  const deleteSection = useCallback(
+    (id: string) => {
+      setData(prev => {
+        const next = prev.filter(sec => sec.id !== id);
+        onChangeSections?.(next);
+        return next;
+      });
+    },
+    [onChangeSections],
+  );
+
+  const renderSection = useCallback(
+    (props: any) => {
+      const { element, attributes, children } = props;
+      if (element.type !== 'section') return undefined;
+      const attrs: any = { ...attributes };
+      if (element.editable === false) {
+        attrs.contentEditable = false;
+        attrs.suppressContentEditableWarning = true;
+      }
+      return (
+        <div {...attrs} data-section-id={element.sectionId}>
+          {children}
+          {element.editable !== false && (
+            <button onClick={() => deleteSection(element.sectionId)}>Delete</button>
+          )}
+        </div>
+      );
+    },
+    [deleteSection],
+  );
+
+  return (
+    <Editor
+      key={data.map(s => s.id).join(',')}
+      initialValue={combinedValue as any}
+      onChangeValue={handleChange}
+      className={className}
+      renderElement={renderSection}
+    />
+  );
+}
+

--- a/packages/react/src/Editor.tsx
+++ b/packages/react/src/Editor.tsx
@@ -22,6 +22,7 @@ export function Editor({
   readOnly,
   collaborative,
   collabUrl,
+  renderElement: customRenderElement,
 }: EditorProps) {
   const { editor, value, onChange } = useEditor({
     initialValue,
@@ -34,7 +35,7 @@ export function Editor({
     null,
   );
 
-  const renderElement = useCallback(
+  const baseRenderElement = useCallback(
     (props: RenderElementProps) => {
       const { element, attributes, children } = props as any;
       if (element.type === 'image') {
@@ -70,6 +71,15 @@ export function Editor({
       return <DefaultElement {...props} />;
     },
     [editor, setToolbarPos],
+  );
+
+  const renderElement = useCallback(
+    (props: RenderElementProps) => {
+      const custom = customRenderElement?.(props);
+      if (custom) return custom;
+      return baseRenderElement(props);
+    },
+    [baseRenderElement, customRenderElement],
   );
 
   const renderLeaf = useCallback((props: RenderLeafProps) => {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,3 +4,4 @@ export * from './Preview';
 export * from './renderToHtml';
 export * from './exportDocument';
 export * from './useEditor';
+export * from './CompositeEditor';

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,4 +1,5 @@
 import type { Descendant } from 'slate';
+import type { RenderElementProps } from 'slate-react';
 
 export interface Block {
   /** Block type identifier, e.g. `paragraph` */
@@ -33,6 +34,8 @@ export interface EditorProps {
   collaborative?: boolean;
   /** Websocket endpoint for collaborative editing */
   collabUrl?: string;
+  /** Custom element renderer */
+  renderElement?: (props: RenderElementProps) => JSX.Element | undefined;
 }
 
 export type UseEditorOptions = Pick<EditorProps, 'initialValue' | 'onChangeValue' | 'collaborative' | 'collabUrl'>;
@@ -62,4 +65,16 @@ export interface ExportOptions {
   /** Multiplier applied to the poll interval after each attempt */
   backoffFactor?: number;
   maxPolls?: number;
+}
+
+export interface Section {
+  id: string;
+  value: Descendant[];
+  editable?: boolean;
+}
+
+export interface CompositeEditorProps {
+  sections: Section[];
+  onChangeSections?: (sections: Section[]) => void;
+  className?: string;
 }


### PR DESCRIPTION
## Summary
- replace SectionedEditor with CompositeEditor that renders all sections inside one editor and allows section deletion
- allow Editor to accept custom renderElement for section wrappers
- update types with new CompositeEditorProps and renderElement support

## Testing
- `cd packages/react && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af520978f88325b43829f8e234dead