### PR TITLE
Refactor mark toggling and document composite editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ or independently to render trusted HTML and deliver PDF exports.
 This repository hosts two packages:
 
 - `packages/react` – React components built on **Slate** with optional collaborative editing: `Editor`,
-  `Preview`, `renderToHtml`, and `exportDocument` for delegating PDF export.
+  `CompositeEditor`, `Preview`, `renderToHtml`, and `exportDocument` for delegating PDF export.
 - `packages/rails` – Rails engine (`draft_forge`) exposing `/draft_forge` endpoints
   for async HTML → PDF via **Grover** (Puppeteer). Includes
   server‑side HTML sanitization and Active Storage delivery.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,6 +13,7 @@ The repository hosts two packages that can be used together or separately:
 Reusable components and helpers for building authoring interfaces.
 
 - **Editor** – headless editor powered by Slate with an inline formatting toolbar.
+- **CompositeEditor** – manage multiple sections with independent editability.
 - **Preview** – client‑side HTML preview for block data.
 - **renderToHtml** – helper for server‑side rendering.
 - **exportDocument** – delegates PDF generation to a backend service.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -2,7 +2,9 @@
 
 Standalone React helpers for rich-text authoring with delegated PDF export. Includes:
 
-- **Editor** – headless rich-text editor powered by Slate with optional collaborative editing, an inline formatting toolbar, and support for non-editable blocks via an `editable` flag
+- **Editor** – headless rich-text editor powered by Slate with optional collaborative editing, an inline formatting toolbar, and
+  support for non-editable blocks via an `editable` flag
+- **CompositeEditor** – combines multiple editable sections into one editor instance
 - **Preview** – client-side HTML preview of block data
 - **renderToHtml** – helper for server-side rendering
 - **exportDocument** – delegates export to a backend service

--- a/packages/react/src/Editor.tsx
+++ b/packages/react/src/Editor.tsx
@@ -11,6 +11,7 @@ import { Editor as SlateEditor, Transforms, Text, Range, NodeEntry } from 'slate
 import { useEditor } from './useEditor';
 import type { EditorProps } from './types';
 import { InlineToolbar } from './InlineToolbar';
+import { toggleMark } from './marks';
 
 export function Editor({
   initialValue,
@@ -126,27 +127,17 @@ export function Editor({
     [searchQuery],
   );
 
-  const toggleMark = useCallback((format: string) => {
-    const marks = SlateEditor.marks(editor);
-    const isActive = marks ? (marks as any)[format] === true : false;
-    if (isActive) {
-      SlateEditor.removeMark(editor, format);
-    } else {
-      SlateEditor.addMark(editor, format, true);
-    }
-  }, [editor]);
-
   const handleKeyDown = useCallback((event: React.KeyboardEvent) => {
     if (!event.ctrlKey && !event.metaKey) return;
     if (event.key === 'b') {
       event.preventDefault();
-      toggleMark('bold');
+      toggleMark(editor, 'bold');
     }
     if (event.key === 'i') {
       event.preventDefault();
-      toggleMark('italic');
+      toggleMark(editor, 'italic');
     }
-  }, [toggleMark]);
+  }, [editor]);
 
   const updateToolbar = useCallback(() => {
     const sel = window.getSelection();

--- a/packages/react/src/InlineToolbar.tsx
+++ b/packages/react/src/InlineToolbar.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useSlate } from 'slate-react';
 import { Editor as SlateEditor, Transforms, Element as SlateElement } from 'slate';
+import { toggleMark } from './marks';
 
 interface ToolbarProps {
   position: { top: number; left: number } | null;
@@ -9,30 +10,25 @@ interface ToolbarProps {
 
 export const InlineToolbar: React.FC<ToolbarProps> = ({ position, onRequestClose }) => {
   const editor = useSlate();
-  if (!position) return null;
 
-  const toggleMark = (format: string) => {
-    const marks = SlateEditor.marks(editor);
-    const isActive = marks ? (marks as any)[format] === true : false;
-    if (isActive) {
-      SlateEditor.removeMark(editor, format);
-    } else {
-      SlateEditor.addMark(editor, format, true);
-    }
+  const handleToggleMark = useCallback((format: string) => {
+    toggleMark(editor, format);
     onRequestClose();
-  };
+  }, [editor, onRequestClose]);
 
-  const imageEntry = SlateEditor.above(editor, {
-    match: n => SlateElement.isElement(n) && (n as any).type === 'image',
-  });
-
-  const insertImage = () => {
+  const insertImage = useCallback(() => {
     const url = window.prompt('Enter image URL');
     if (!url) return;
     const image = { type: 'image', url, width: 200, children: [{ text: '' }] } as any;
     Transforms.insertNodes(editor, image);
     onRequestClose();
-  };
+  }, [editor, onRequestClose]);
+
+  if (!position) return null;
+
+  const imageEntry = SlateEditor.above(editor, {
+    match: n => SlateElement.isElement(n) && (n as any).type === 'image',
+  });
 
   const buttonStyle: React.CSSProperties = {
     background: 'transparent',
@@ -77,7 +73,7 @@ export const InlineToolbar: React.FC<ToolbarProps> = ({ position, onRequestClose
             style={buttonStyle}
             onMouseDown={e => {
               e.preventDefault();
-              toggleMark('bold');
+              handleToggleMark('bold');
             }}
           >
             <strong>B</strong>
@@ -86,7 +82,7 @@ export const InlineToolbar: React.FC<ToolbarProps> = ({ position, onRequestClose
             style={buttonStyle}
             onMouseDown={e => {
               e.preventDefault();
-              toggleMark('italic');
+              handleToggleMark('italic');
             }}
           >
             <em>I</em>

--- a/packages/react/src/marks.ts
+++ b/packages/react/src/marks.ts
@@ -1,0 +1,15 @@
+import { Editor } from 'slate';
+
+/**
+ * Toggle a formatting mark on the current selection.
+ * Mirrors Slate's recommended helper from the documentation.
+ */
+export function toggleMark(editor: Editor, format: string) {
+  const marks = Editor.marks(editor) as Record<string, unknown> | null;
+  const isActive = marks ? marks[format] === true : false;
+  if (isActive) {
+    Editor.removeMark(editor, format);
+  } else {
+    Editor.addMark(editor, format, true);
+  }
+}


### PR DESCRIPTION
## Summary
- centralize Slate mark toggling logic in new `toggleMark` helper
- reuse helper in editor toolbar and hotkeys
- document `CompositeEditor` in readmes and overview

## Testing
- `cd packages/react && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af563f9cc48325b66740c09e273149